### PR TITLE
point out to correct packet in pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Python 3
 
 pySerial
 ```
-pip install serial
+pip install pyserial
 ```
 
 ## Command Interface


### PR DESCRIPTION
Hi,
I believe the correct library to be used for serial port handling is [pyserial](https://github.com/pyserial/pyserial).